### PR TITLE
Add youth membership production API url into GitLab config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,4 +65,4 @@ production:
     K8S_SECRET_OPEN_CITY_PROFILE_API_NAME: "https://api.hel.fi/auth/helsinkiprofile"
     K8S_SECRET_OPEN_CITY_PROFILE_API_URL: "https://api.hel.fi/profiili/graphql/"
     K8S_SECRET_YOUTH_MEMBERSHIP_API_NAME: "https://api.hel.fi/auth/jassariapi"
-    K8S_SECRET_YOUTH_MEMBERSHIP_API_URL: "https://api.hel.fi/jassari/graphql/"
+    K8S_SECRET_YOUTH_MEMBERSHIP_API_URL: "https://jassari.api.hel.fi/graphql/"


### PR DESCRIPTION
This PR adds correct youth membership production API URL.

Refs YM-426