### PR TITLE
YM-446 | Forward client IP in X-Forwarded-For header

### DIFF
--- a/src/dataSources.ts
+++ b/src/dataSources.ts
@@ -182,5 +182,10 @@ export class AuthenticatedDataSource extends FileUploadDataSource {
           "Accept-Language",
           (context as any).acceptLanguage
       );
+
+      request.http.headers.set(
+          "X-Forwarded-For",
+          (context as any).clientIP
+      );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ const gateway = new ApolloGateway({
         context: ({ req }) => {
             const apiTokens: string = req.headers["api-tokens"] || "";
             const acceptLanguage: string = req.headers["accept-language"] || "";
-            return { apiTokens, acceptLanguage };
+            const clientIP: string = req.headers["x-real-ip"] || req.ip;
+            return { apiTokens, acceptLanguage, clientIP };
         },
         debug: debug,
         playground: debug,


### PR DESCRIPTION
This PR forwards the client IP to the backend so that backend is able to log (audit logging) the correct IP for the client and not the IP of the federation proxy.

Refs YM-446