### PR TITLE
Chore | Add trigger that allows manually run staging workflow.

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
+        if: github.event_name == 'push' || github.event.inputs.build_required == 'true'
         uses: andersinno/kolga-build-action@v2
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+    inputs:
+      build_required:
+        description: "Build images (true/false)"
+        required: true
+        default: "false"
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   CONTAINER_REGISTRY_USER: ${{ secrets.GHCR_CONTAINER_REGISTRY_USER }}


### PR DESCRIPTION
This PR adds `workflow_dispatch` trigger. With this in place it's possible to manually run staging workflow from Actions - tab.